### PR TITLE
chore: minor bugfixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
+
 
 plugins {
   id("java")
@@ -7,7 +9,7 @@ plugins {
 }
 
 group = "com.block"
-version = "1.3.0"
+version = "1.3.1"
 
 repositories {
   mavenCentral()
@@ -26,7 +28,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.commonmark:commonmark:0.22.0")
   intellijPlatform {
-    intellijIdeaUltimate("2024.1.5")
+    intellijIdeaUltimate("2024.2.3")
     pluginVerifier()
     zipSigner()
     instrumentationTools()
@@ -45,6 +47,7 @@ tasks {
 
   patchPluginXml {
     sinceBuild.set("232")
+    untilBuild.set("250.*")
   }
 
   signPlugin {

--- a/src/main/kotlin/com/block/gooseintellij/actions/GoosePluginStartupActivity.kt
+++ b/src/main/kotlin/com/block/gooseintellij/actions/GoosePluginStartupActivity.kt
@@ -16,6 +16,8 @@ class GoosePluginStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         // Check for Goose and SQ Goose availability and paths
         GooseUtils.checkGooseAvailability()
+        GooseUtils.getAvailableProviders()
+        GooseUtils.getToolkitsWithDescriptions()
 
         // Check for .goosehints file and create it if it does not exist
         val gooseHintsFile = File(project.basePath, ".goosehints")
@@ -58,7 +60,7 @@ class GoosePluginStartupActivity : ProjectActivity {
         GooseTerminalWidgetFactory().createToolWindowContent(project, toolWindow!!)
         gooseTerminal = contentManager?.getContent(0)?.component as? GooseTerminalWidget
         gooseTerminal?.writeToTerminal("Restarting session...")
-        GooseUtils.startGooseSession(true, gooseTerminal, project)
+        GooseUtils.startGooseSession(gooseTerminal, project)
 
         if (!toolWindow.isVisible) {
             toolWindow.activate(null)


### PR DESCRIPTION
This pull request includes several changes to improve the Goose IntelliJ plugin by refactoring utility methods and updating the startup activity and profile selection logic. The most important changes include adding new utility methods for fetching available providers and toolkits, refactoring the startup activity to use these new methods, and simplifying the profile selection logic.

### Refactoring and Utility Methods:

* Added methods `GooseUtils.getAvailableProviders` and `GooseUtils.getToolkitsWithDescriptions` to fetch available providers and toolkits with descriptions. (`src/main/kotlin/com/block/gooseintellij/utils/GooseUtils.kt`) [[1]](diffhunk://#diff-7698b905492e273da229e90cc4b8a39775c97c9a0375a0e3500c990fa910bafbR134-R174) [[2]](diffhunk://#diff-7698b905492e273da229e90cc4b8a39775c97c9a0375a0e3500c990fa910bafbR115-R118) [[3]](diffhunk://#diff-7698b905492e273da229e90cc4b8a39775c97c9a0375a0e3500c990fa910bafbR21-R35)

### Startup Activity Improvements:

* Updated `GoosePluginStartupActivity` to use the new utility methods `GooseUtils.getAvailableProviders` and `GooseUtils.getToolkitsWithDescriptions`. (`src/main/kotlin/com/block/gooseintellij/actions/GoosePluginStartupActivity.kt`) [[1]](diffhunk://#diff-bc921c1ed4f919cae0d45ad377c7b37feaf91313901eff8288323aa020700d7aR19-R20) [[2]](diffhunk://#diff-bc921c1ed4f919cae0d45ad377c7b37feaf91313901eff8288323aa020700d7aL61-R63)

### Profile Selection Simplification:

* Simplified `SelectGooseProfileAction` by removing the redundant `getAvailableProviders` method and using `GooseUtils.getAvailableProviders` instead. (`src/main/kotlin/com/block/gooseintellij/actions/SelectGooseProfileAction.kt`) [[1]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL43-R43) [[2]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL67-L74)
* Replaced inline logic for fetching toolkits with descriptions with `GooseUtils.getToolkitsWithDescriptions` in `SelectGooseProfileAction`. (`src/main/kotlin/com/block/gooseintellij/actions/SelectGooseProfileAction.kt`) [[1]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL84-L98) [[2]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL107-R85) [[3]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL182-R160)

### Code Cleanup:

* Refactored `GooseUtils.startGooseSession` to remove the `usingSqGoose` parameter and determine the Goose instance internally. (`src/main/kotlin/com/block/gooseintellij/utils/GooseUtils.kt`) [[1]](diffhunk://#diff-7698b905492e273da229e90cc4b8a39775c97c9a0375a0e3500c990fa910bafbR21-R35) [[2]](diffhunk://#diff-7698b905492e273da229e90cc4b8a39775c97c9a0375a0e3500c990fa910bafbL75-R79)
* Improved readability by reformatting code blocks in `SelectGooseProfileAction`. (`src/main/kotlin/com/block/gooseintellij/actions/SelectGooseProfileAction.kt`) [[1]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL213-R196) [[2]](diffhunk://#diff-904735980bc8b6d285f446ee452d9a9db0c965728e10f0d76c468ab9aed0959dL240-R251)